### PR TITLE
added link to React Native to Release header search path

### DIFF
--- a/RCTLogentries.h
+++ b/RCTLogentries.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RCTLogentries : NSObject <RCTBridgeModule>
 

--- a/RCTLogentries.xcodeproj/project.pbxproj
+++ b/RCTLogentries.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-logentries",
   "description": "A React Native library that allows to log to remote logging service Logentries",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Joel Costa <joelrfcosta@gmail.com> (https://github.com/joelrfcosta)",
   "keywords": [
     "react-native",


### PR DESCRIPTION
Hi!

I fixed problem with release build if app contains logentries plugin.

For details (the same issue) please look here:
https://github.com/naoufal/react-native-passcode-auth/issues/2