### PR TITLE
Create react-native-logentries.podspec

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-logentries",
   "description": "A React Native library that allows to log to remote logging service Logentries",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "author": "Joel Costa <joelrfcosta@gmail.com> (https://github.com/joelrfcosta)",
   "license": "MIT",
   "contributors": [

--- a/library/react-native-logentries.podspec
+++ b/library/react-native-logentries.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['repository']['url']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/joelrfcosta/react-native-logentries.git", :tag => "{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end

--- a/library/react-native-logentries.podspec
+++ b/library/react-native-logentries.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['repository']['url']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/joelrfcosta/react-native-logentries.git", :tag => "{s.version}" }
+  s.source       = { :git => "https://github.com/joelrfcosta/react-native-logentries.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
Creates missing podspec needed for automatic linking as of React Native 0.60.0 and fixes the package.json's version to equal the latest tag.